### PR TITLE
delete redundant info; use realine in shell-read

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@
 *.a
 ins
 ins_cli
+Makefile
 output/*
 sandbox/data/
+sandbox/ins.flag

--- a/sandbox/ins_shell.sh
+++ b/sandbox/ins_shell.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 while true
 do
-	read -p "galaxy ins> " cmd arg1 arg2
+	read -e -p "galaxy ins> " cmd arg1 arg2
 	case $cmd in
 	"show")
 		sh ./show_cluster.sh


### PR DESCRIPTION
rt.