### PR TITLE
Fix bug that when login operation spread to follower the uuid isn't consistent

### DIFF
--- a/sandbox/user_test.sh
+++ b/sandbox/user_test.sh
@@ -12,7 +12,7 @@ sleep 1
 COUNTER=0
 while [ $COUNTER -lt 100 ];
 do
-	printf 'put %d value\nscan\nlogout\n' $COUNTER | nohup ../output/bin/ins_cli --ins_cmd=login --flagfile=ins.flag --ins_key=zhangkai --ins_value=123456 &>> out &
+	printf 'put %d value\nscan\nlogout\n' $COUNTER | nohup ../output/bin/ins_cli --ins_cmd=login --flagfile=ins.flag --ins_key=zhangkai --ins_value=123456 &> out &
 	let COUNTER=COUNTER+1
 done
 

--- a/server/ins_node_impl.cc
+++ b/server/ins_node_impl.cc
@@ -286,9 +286,12 @@ void InsNodeImpl::CommitIndexObserv() {
                     }
                     break;
                 case kLogin:
-                    log_status = user_manager_->Login(log_entry.user, log_entry.key, &new_uuid);
+                    log_status = user_manager_->Login(log_entry.key,
+                                                      log_entry.value,
+                                                      log_entry.user);
                     if (log_status == kOk) {
-                        data_store_->OpenDatabase(log_entry.user);
+                        new_uuid = log_entry.user;
+                        data_store_->OpenDatabase(log_entry.key);
                     }
                     break;
                 case kLogout:
@@ -1813,8 +1816,10 @@ void InsNodeImpl::Login(::google::protobuf::RpcController* /*controller*/,
     const std::string& passwd = request->passwd();
     LOG(DEBUG, "client wants to login :%s", username.c_str());
     LogEntry log_entry;
-    log_entry.user = username;
-    log_entry.key = passwd;
+    log_entry.user = UserManager::CalcUuid(username);
+    LOG(DEBUG, "now calc uuid :%s", log_entry.user.c_str());
+    log_entry.key = username;
+    log_entry.value = passwd;
     log_entry.term = current_term_;
     log_entry.op = kLogin;
     binlogger_->AppendEntry(log_entry);

--- a/server/user_manage.h
+++ b/server/user_manage.h
@@ -17,7 +17,7 @@ public:
     UserManager(const std::string& data_dir, const UserInfo& root);
     virtual ~UserManager() { }
 
-    Status Login(const std::string& name, const std::string& password, std::string* uuid);
+    Status Login(const std::string& name, const std::string& password, const std::string& uuid);
     Status Logout(const std::string& uuid);
     Status Register(const std::string& name, const std::string& password);
     Status ForceOffline(const std::string& myid, const std::string& name);


### PR DESCRIPTION
Modified Login interface in user_manager. The uuid is no longer generate inside the login operation.
Login rpc will write binlog with a certain uuid to coordinate all the nodes.